### PR TITLE
[504:robot:] Fix Configuration Setting Issue and Update Docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,37 @@ Setup Python Development Environment
 
     $ make test-all
 
+Configuration Settings
+----------------------
+
+The following environment variables are available to configure behavior of services that use this library:
+
+.. list-table:: **Environment Variable Settings**
+   :widths: 25 35 50
+
+   * - **ENV**
+     - **Default Value for 'local' Environment**
+     - **Description**
+
+   * - ``SERVICE_PUBLIC_URL``
+     - ``http://localhost:5000``
+     - The public URL for this service. (Used for generating OpenAPI clients)
+   * - ``SERVICE_PRIVATE_URL``
+     - ``http://localhost:5000``
+     - The private URL for this service. (Used for generating OpenAPI clients)
+   * - ``OIDC_ISSUER_URL``
+     - *None* (must be provided)
+     - The Keycloak IAM URL to use for authentication.
+   * - ``OIDC_REALM``
+     - *None* (must be provided)
+     - The Keycloak IAM realm to use for authentication.
+   * - ``SQLALCHEMY_DATABASE_URI``
+     - ``sqlite:///:memory:``
+     - The URI for a PostgreSQL database to use for persistent storage.
+   * - ``OPENAPI_GEN_SERVER_URL``
+     - ``http://api.openapi-generator.tech``
+     - The OpenAPI online generator server URL to use for creating clients.
+
 Contributing
 ------------
 

--- a/flask_ligand/default_settings.py
+++ b/flask_ligand/default_settings.py
@@ -43,14 +43,13 @@ class _DefaultConfig(dict):  # type: ignore
             "OPENAPI_SWAGGER_UI_URL": "https://cdn.jsdelivr.net/npm/swagger-ui-dist/",
         }
 
-        # TODO: This needs to be changed to using an env_var for configuring PostgreSQL as the database. []
         basic_default_settings: dict[str, Any] = {
             "SERVICE_PUBLIC_URL": os.getenv("SERVICE_PUBLIC_URL"),
             "SERVICE_PRIVATE_URL": os.getenv("SERVICE_PRIVATE_URL"),
             "API_SPEC_OPTIONS": {"servers": [{"url": os.getenv("SERVICE_PUBLIC_URL"), "description": "Public URL"}]},
             "JSON_SORT_KEYS": False,
             "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-            "SQLALCHEMY_DATABASE_URI": os.getenv("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:"),
+            "SQLALCHEMY_DATABASE_URI": os.getenv("SQLALCHEMY_DATABASE_URI"),
             "VERIFY_SSL_CERT": True,
         }
 

--- a/flask_ligand/views/openapi.py
+++ b/flask_ligand/views/openapi.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 # Globals
 # ======================================================================================================================
 BLP = Blueprint(
-    "Emotimetrix OpenAPI Generator",
+    "OpenAPI Client Generator",
     __name__,
     url_prefix="/openapi",
     description="Provides download links to pre-configured OpenAPI clients for this service.",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -62,6 +62,7 @@ class TestDefaultConfig(object):
             "SERVICE_PUBLIC_URL": "http://service.public.url",
             "SERVICE_PRIVATE_URL": "http://service.private.url",
             "OIDC_REALM": "oidc_realm",
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
         }
 
         mocker.patch.dict("os.environ", mocked_env)
@@ -86,7 +87,7 @@ class TestDefaultConfig(object):
             "API_SPEC_OPTIONS": {"servers": [{"url": mocked_env["SERVICE_PUBLIC_URL"], "description": "Public URL"}]},
             "JSON_SORT_KEYS": False,
             "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "SQLALCHEMY_DATABASE_URI": mocked_env["SQLALCHEMY_DATABASE_URI"],
             "VERIFY_SSL_CERT": True,
             "OIDC_REALM": mocked_env["OIDC_REALM"],
             "JWT_TOKEN_LOCATION": "headers",


### PR DESCRIPTION
The "SQLALCHEMY_DATABASE_URI" setting was being set to a default for the
production environment which is not correct.

Also, the configuration settings section was completely missing from the
README! Whoops!

Found one mention of the old project name still lurking around which was
removed.