### PR TITLE
[543:robot:] Fix the Docs

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -49,7 +49,7 @@ Api
 
 |
 
-.. autoclass:: flask_ligand.extensions.api.BaseQuery
+.. autoclass:: flask_ligand.extensions.api.Query
     :members:
 
 |

--- a/flask_ligand/extensions/api.py
+++ b/flask_ligand/extensions/api.py
@@ -143,7 +143,7 @@ class SQLCursorPage(Page):
 class Query(QueryOrig):  # type: ignore
     """
     Enable customized REST JSON error messages for 'get_or_404' and 'first_or_404' methods for
-    :class:`BaseQuery <flask_sqlalchemy.BaseQuery>`.
+    :class:`Query <flask_sqlalchemy.query.Query>`.
     """
 
     def get_or_404(self, ident: object, description: Optional[str] = None) -> Any:


### PR DESCRIPTION
D'oh! Forgot to check the docs for references to the depecrated Flask-SQLAlchemy classes and methods that were renamed.