### PR TITLE
[543:robot:] Refactor for flask-smorest Etag Changes

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -190,8 +190,8 @@ button in the :swagger-ui:`SwaggerUI documentation <>` by providing the  to the
 .. code-block:: python
 
     @BLP.route("/")
+    @BLP.etag
     class Pets(MethodView):
-        @BLP.etag
         @BLP.arguments(PetQueryArgsSchema, location="query")
         @BLP.response(200, PetSchema(many=True))
         @BLP.paginate(SQLCursorPage)  # noqa
@@ -202,7 +202,6 @@ button in the :swagger-ui:`SwaggerUI documentation <>` by providing the  to the
 
             return items
 
-        @BLP.etag
         @BLP.arguments(PetSchema)
         @BLP.response(201, PetSchema)
         @BLP.doc(security=BEARER_AUTH)
@@ -299,8 +298,8 @@ Use :func:`abort <flask_ligand.extensions.api.abort>` to return an error respons
         # Classes: Public
         # ======================================================================================================================
         @BLP.route("/")
+        @BLP.etag
         class Pets(MethodView):
-            @BLP.etag
             @BLP.arguments(PetQueryArgsSchema, location="query")
             @BLP.response(200, PetSchema(many=True))
             @BLP.paginate(SQLCursorPage)  # noqa
@@ -311,7 +310,6 @@ Use :func:`abort <flask_ligand.extensions.api.abort>` to return an error respons
 
                 return items
 
-            @BLP.etag
             @BLP.arguments(PetSchema)
             @BLP.response(201, PetSchema)
             @BLP.doc(security=BEARER_AUTH)
@@ -329,8 +327,8 @@ Use :func:`abort <flask_ligand.extensions.api.abort>` to return an error respons
 
 
         @BLP.route("/<uuid:item_id>")
+        @BLP.etag
         class PetsById(MethodView):
-            @BLP.etag
             @BLP.response(200, PetSchema)
             def get(self, item_id: UUID) -> PetModel:
                 """Get a pet by ID."""
@@ -339,7 +337,6 @@ Use :func:`abort <flask_ligand.extensions.api.abort>` to return an error respons
 
                 return item
 
-            @BLP.etag
             @BLP.arguments(PetSchema)
             @BLP.response(200, PetSchema)
             @BLP.doc(security=BEARER_AUTH)
@@ -358,7 +355,6 @@ Use :func:`abort <flask_ligand.extensions.api.abort>` to return an error respons
 
                 return item
 
-            @BLP.etag
             @BLP.response(204)
             @BLP.doc(security=BEARER_AUTH)
             @jwt_role_required(role="admin")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -63,8 +63,8 @@ class IntegrationTestSchema(AutoSchema):
 
 
 @BLP.route("/")
+@BLP.etag
 class IntegrationTestView(MethodView):
-    @BLP.etag
     @BLP.response(200, IntegrationTestSchema(many=True))
     @jwt_role_required(role="user")
     def get(self):
@@ -73,7 +73,6 @@ class IntegrationTestView(MethodView):
 
         return items
 
-    @BLP.etag
     @BLP.arguments(IntegrationTestSchema)
     @BLP.response(201, IntegrationTestSchema)
     def post(self, new_item):

--- a/tests/unit/test_database_extension.py
+++ b/tests/unit/test_database_extension.py
@@ -75,8 +75,8 @@ class DatabaseTestQueryArgsSchema(Schema):
 
 
 @BLP.route("/")
+@BLP.etag
 class DatabaseTestView(MethodView):
-    @BLP.etag
     @BLP.arguments(DatabaseTestQueryArgsSchema, location="query")
     @BLP.response(200, DatabaseTestSchema(many=True))
     @BLP.paginate(SQLCursorPage)  # noqa
@@ -84,7 +84,6 @@ class DatabaseTestView(MethodView):
 
         return DatabaseTestModel.query.filter_by(**args)
 
-    @BLP.etag
     @BLP.arguments(DatabaseTestSchema)
     @BLP.response(201, DatabaseTestSchema)
     def post(self, new_item):
@@ -97,8 +96,8 @@ class DatabaseTestView(MethodView):
 
 
 @BLP.route("/first")
+@BLP.etag
 class DatabaseTestViewFirst(MethodView):
-    @BLP.etag
     @BLP.response(200, DatabaseTestSchema)
     def get(self):
 
@@ -106,14 +105,13 @@ class DatabaseTestViewFirst(MethodView):
 
 
 @BLP.route("/<uuid:item_id>")
+@BLP.etag
 class DatabaseTestViewById(MethodView):
-    @BLP.etag
     @BLP.response(200, DatabaseTestSchema)
     def get(self, item_id):
 
         return DatabaseTestModel.query.get_or_404(item_id, description="Invalid item!")
 
-    @BLP.etag
     @BLP.arguments(DatabaseTestSchema)
     @BLP.response(200, DatabaseTestSchema)
     def put(self, new_item, item_id):

--- a/tests/unit/test_jwt_extension.py
+++ b/tests/unit/test_jwt_extension.py
@@ -57,8 +57,8 @@ class JwtTestSchema(AutoSchema):
 
 
 @BLP.route("/")
+@BLP.etag
 class JwtTestView(MethodView):
-    @BLP.etag
     @BLP.response(200, JwtTestSchema(many=True))
     @jwt_role_required(role="user")
     def get(self):
@@ -67,7 +67,6 @@ class JwtTestView(MethodView):
 
         return items
 
-    @BLP.etag
     @BLP.arguments(JwtTestSchema)
     @BLP.response(201, JwtTestSchema)
     def post(self, new_item):
@@ -79,8 +78,8 @@ class JwtTestView(MethodView):
 
 
 @BLP.route("/broken/")
+@BLP.etag
 class JwtBrokenView(MethodView):
-    @BLP.etag
     @BLP.response(200, JwtTestSchema(many=True))
     @jwt_role_required(role="broken")
     def get(self):


### PR DESCRIPTION
The 'flask-smorest' library simplified decorating Blueprint classes for Etag support. I updated tests and documentation to reflect the new approach.