### PR TITLE
[542] Drop Pre-Commit Tox Environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,10 @@ type-check: ## check Python types using mypy
 format: ## format code using black
 	@black flask_ligand app.py setup.py tests
 
+.PHONY: run-pre-commit
+run-pre-commit: check-pre-commit ## run pre-commit against all files
+	@pre-commit run --all-files
+
 .PHONY: test
 test: ## run tests quickly with the default Python
 	@pytest -p no:warnings tests/unit

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 skipsdist = true
-envlist = py310, py311, pre-commit
+envlist = py310, py311
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.10: py310, pre-commit
+    3.10: py310
     3.11-dev: py311
 
 [testenv]
@@ -18,10 +18,3 @@ deps =
 commands =
     pip3 install -U pip
     py.test --basetemp={envtmpdir} tests/unit
-
-[pre-commit]
-basepython = python3
-skip_install = true
-
-[testenv:pre-commit]
-commands = pre-commit run --all-files


### PR DESCRIPTION
The pre-commit GitHub Action works fine and is faster than having a tox environment run the tasks therefore the pre-commit tox environment has been removed and a Makefile target created to allow for on-demand execution of pre-commit.