### PR TITLE
[545] Update to Python 3.11 Final

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11-dev']
+        python-version: ['3.10', '3.11']
 
     steps:
       - name: Git Checkout

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 [gh-actions]
 python =
     3.10: py310
-    3.11-dev: py311
+    3.11: py311
 
 [testenv]
 passenv = SSH_AUTH_SOCK


### PR DESCRIPTION
The official final version of Python 3.11 has been released. Update GitHub/tox to start using the new version.