### PR TITLE
[536:sparkles:] Generate OpenAPI Clients Offline

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,6 +1,6 @@
 .. module:: flask_ligand
 
-.. rstcheck: ignore-roles=sqlalchemy,swagger-ui
+.. rstcheck: ignore-roles=sqlalchemy,swagger-ui,openapi-gen
 .. rstcheck: ignore-directives=autoclass,autofunction,autodata
 
 =============
@@ -102,9 +102,10 @@ The ``flask_ligand.default_settings`` module defines default settings for the ``
 Views
 =====
 
-The ``flask_ligand.default_settings`` module contains built-in endpoints
-(a.k.a. :class:`Flask View <flask.views.MethodView>`) for `generating OpenAPI clients`_ for TypeScript and Python. Also,
-a global variable is provided that will add an "Authorize" button to the :swagger-ui:`SwaggerUI documentation <>`.
+The ``flask_ligand.views.openapi`` module contains built-in endpoints
+(a.k.a. :class:`Flask View <flask.views.MethodView>`) for :openapi-gen:`generating OpenAPI clients <>` for TypeScript
+and Python. Also, a global variable is provided that will add an "Authorize" button to the
+:swagger-ui:`SwaggerUI documentation <>`.
 
 .. autoclass:: flask_ligand.views.openapi.OpenApiTypescriptAxios
     :members:  get
@@ -120,5 +121,3 @@ a global variable is provided that will add an "Authorize" button to the :swagge
     :no-value:
 
 |
-
-.. _`generating OpenAPI clients`: https://openapi-generator.tech/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ extlinks = {
     "swagger-ui": ("https://swagger.io/tools/swagger-ui/%s", None),
     "auth0": ("https://auth0.com/%s", None),
     "oidc": ("https://openid.net/%s", None),
+    "openapi-gen": ("https://openapi-generator.tech/%s", None),
 }
 
 intersphinx_mapping = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Guides
 
     quickstart
     configuration
+    openapi
     development
     auth0
 

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -1,0 +1,58 @@
+.. rstcheck: ignore-roles=swagger-ui,openapi-gen
+
+===============
+OpenAPI Support
+===============
+
+The ``flask_ligand.views.openapi`` module contains built-in endpoints for :openapi-gen:`generating OpenAPI clients <>`
+for :class:`TypeScript <flask_ligand.views.openapi.OpenApiTypescriptAxios>` and
+:class:`Python <flask_ligand.views.openapi.OpenApiPython>`.
+
+For OpenAPI client generation to work properly your ``flask-ligand`` based microservice must have the
+``OPENAPI_GEN_SERVER_URL`` `setting configured`_ to a valid :openapi-gen:`OpenAPI Generator Server URL <>`. The
+public OpenAPI generator server URL located at http://api.openapi-generator.tech is also available, but since it is not
+a secure endpoint, it is recommended for use only in testing.
+
+Online Generation
+=================
+
+Any microservice built with ``flask-ligand`` will have the following built-in endpoints for
+:openapi-gen:`generating OpenAPI clients <>`:
+
+* ``/openapi/typescript-axios/``: Generate a TypeScript client download link.
+* ``/openapi/python/``: Generate a Python client download link.
+
+For more details about the endpoint, use the included :swagger-ui:`SwaggerUI documentation <>`  with your
+``flask-ligand`` based microservice running locally by opening a browser and navigating to
+http://localhost:5000/apidocs.
+
+Online Example
+--------------
+
+Generate a Python client download link with your ``flask-ligand`` based microservice running locally::
+
+    curl -X 'GET' \
+      'http://localhost:5000/openapi/python/' \
+      -H 'accept: application/json'
+
+Offline Generation
+==================
+
+The ``genclient`` and ``openapi`` :doc:`Flask sub-commands <flask:cli>` are provided for
+:openapi-gen:`offline generation of OpenAPI clients <>` for your ``flask-ligand`` based microservice CI/CD pipelines.
+Use ``flask genclient --help`` or ``flask openapi --help`` to get more details about the functionality that the
+sub-commands provide.
+
+.. important:: In order to fully utilize offline generation the ``FLASK_ENV`` environment variable should be set to
+    ``cli`` which will prevent ``flask-ligand`` from initializing Flask extensions. However, **all settings
+    required** by the `production environment`_ still need to be set to successfully generate an OpenAPI client.
+
+Offline Example
+---------------
+
+Generate a Python client download link with your ``flask-ligand`` based microservice in offline mode::
+
+    FLASK_ENV=cli flask genclient python
+
+.. _`setting configured`: configuration.html#prod
+.. _`production environment`: configuration.html#prod

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -412,39 +412,53 @@ registering the Blueprints for the views.
 
     .. code-block:: python
 
-        """flask-ligand-example package."""
+        """flask-ligand microservice library package."""
 
         # ======================================================================================================================
         # Imports
         # ======================================================================================================================
         from __future__ import annotations
-        import flask_ligand
         from flask import Flask
+        from flask_cors import CORS
         from typing import TYPE_CHECKING
-        from flask_ligand_example import views
+        from flask_ligand.cli import genclient
+        from flask_ligand import extensions, views
+        from flask_ligand.default_settings import flask_environment_configurator
 
 
         # ======================================================================================================================
         # Type Checking
         # ======================================================================================================================
         if TYPE_CHECKING:  # pragma: no cover
-            from typing import Any
+            from typing import Any, Tuple
+            from flask_ligand.extensions.api import Api
 
 
         # ======================================================================================================================
         # Globals
         # ======================================================================================================================
-        __version__ = "0.4.0"
+        __version__ = "0.6.3"
 
 
         # ======================================================================================================================
         # Functions: Public
         # ======================================================================================================================
-        def create_app(flask_env: str, api_title: str, api_version: str, openapi_client_name: str, **kwargs: Any) -> Flask:
+        def create_app(
+            flask_app_name: str,
+            flask_env: str,
+            api_title: str,
+            api_version: str,
+            openapi_client_name: str,
+            **kwargs: Any,
+        ) -> Tuple[Flask, Api]:
             """
             Create Flask application.
 
             Args:
+                flask_app_name: This name is used to find resources on the filesystem, can be used by extensions to improve
+                    debugging information and a lot more. So it's important what you provide one. If you are using a
+                    single module, ``__name__`` is always the correct value. If you however are using a package, it's usually
+                    recommended to hardcode the name of your package.
                 flask_env: Specify the environment to use when launching the flask app. Available environments:
 
                     ``prod``: Configured for use in a production environment.
@@ -454,24 +468,35 @@ registering the Blueprints for the views.
                     ``local``: Configured for use with a local Flask server.
 
                     ``testing``: Configured for use in unit testing.
+
+                    ``cli``: Configured for use in a production environment without initializing extensions. (Use for CI/CD)
                 api_title: The title (name) of the API to display in the OpenAPI documentation.
                 api_version: The semantic version for the OpenAPI client.
                 openapi_client_name: The package name to use for generated OpenAPI clients.
                 kwargs: Additional settings to add to the configuration object or overrides for unprotected settings.
 
             Returns:
-                Fully configured Flask application.
+                A tuple with a fully configured Flask application and an Api ready to register additional Blueprints.
 
             Raises:
                 RuntimeError: Attempted to override a protected setting, specified an additional setting that was not all
                     uppercase or the specified environment is invalid.
             """
 
-            app, api = flask_ligand.create_app(__name__, flask_env, api_title, api_version, openapi_client_name, **kwargs)
+            app = Flask(flask_app_name)
+
+            CORS(app, expose_headers=["x-pagination", "etag"])  # TODO: this needs to be configurable! [271]
+
+            flask_environment_configurator(app, flask_env, api_title, api_version, openapi_client_name, **kwargs)
+
+            api = extensions.create_api(app, True if app.config["ENV"] == "cli" else False)
 
             views.register_blueprints(api)
 
-            return app
+            app.cli.add_command(genclient)
+
+            return app, api
+
 
 Run the App
 -----------
@@ -546,7 +571,7 @@ local Flask server to serve the :swagger-ui:`SwaggerUI documentation <>`.
 
     $ make run
 
-5. Open a browser and navigate to 'http://localhost:5000/apidocs'.
+5. Open a browser and navigate to http://localhost:5000/apidocs.
 6. Click the 'Authorize' button and paste in the JWT access token you created previously.
 
 Now go ahead and start playing around with the API!

--- a/flask_ligand/__init__.py
+++ b/flask_ligand/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from flask import Flask
 from flask_cors import CORS
 from typing import TYPE_CHECKING
+from flask_ligand.cli import genclient
 from flask_ligand import extensions, views
 from flask_ligand.default_settings import flask_environment_configurator
 
@@ -29,7 +30,12 @@ __version__ = "0.6.3"
 # Functions: Public
 # ======================================================================================================================
 def create_app(
-    flask_app_name: str, flask_env: str, api_title: str, api_version: str, openapi_client_name: str, **kwargs: Any
+    flask_app_name: str,
+    flask_env: str,
+    api_title: str,
+    api_version: str,
+    openapi_client_name: str,
+    **kwargs: Any,
 ) -> Tuple[Flask, Api]:
     """
     Create Flask application.
@@ -48,6 +54,8 @@ def create_app(
             ``local``: Configured for use with a local Flask server.
 
             ``testing``: Configured for use in unit testing.
+
+            ``cli``: Configured for use in a production environment without initializing extensions. (Use for CI/CD)
         api_title: The title (name) of the API to display in the OpenAPI documentation.
         api_version: The semantic version for the OpenAPI client.
         openapi_client_name: The package name to use for generated OpenAPI clients.
@@ -67,8 +75,10 @@ def create_app(
 
     flask_environment_configurator(app, flask_env, api_title, api_version, openapi_client_name, **kwargs)
 
-    api = extensions.create_api(app)
+    api = extensions.create_api(app, True if flask_env == "cli" else False)
 
     views.register_blueprints(api)
+
+    app.cli.add_command(genclient)
 
     return app, api

--- a/flask_ligand/cli.py
+++ b/flask_ligand/cli.py
@@ -1,0 +1,49 @@
+"""Custom Flask Commands for Ligand."""
+
+# ======================================================================================================================
+# Imports
+# ======================================================================================================================
+from __future__ import annotations
+import click
+from flask import current_app
+from flask_ligand.controllers import gen_typescript_dl_link, gen_python_dl_link
+
+
+# ======================================================================================================================
+# Functions: Public
+# ======================================================================================================================
+@click.group()
+@click.option(
+    "--private/--public",
+    default=False,
+    show_default=True,
+    help="Generate an OpenAPI download link for the SERVICE_PRIVATE_URL or SERVICE_PUBLIC_URL",
+)
+@click.pass_context
+def genclient(ctx: click.Context, private: bool) -> None:
+    """Generate download links for supported OpenAPI clients."""
+
+    # ensure that ctx.obj exists and is a dict to handle "--help" correctly for sub-commands
+    ctx.ensure_object(dict)
+
+    ctx.obj["PRIVATE"] = private
+
+
+@genclient.command()
+@click.pass_context
+def typescript(ctx: click.Context) -> None:
+    """Generate a download link for the TypeScript OpenAPI client."""
+
+    private: bool = ctx.obj["PRIVATE"]
+
+    print(gen_typescript_dl_link(current_app, private)["link"])  # pragma: no cover
+
+
+@genclient.command()
+@click.pass_context
+def python(ctx: click.Context) -> None:
+    """Generate a download link for the Python OpenAPI client."""
+
+    private: bool = ctx.obj["PRIVATE"]
+
+    print(gen_python_dl_link(current_app, private)["link"])  # pragma: no cover

--- a/flask_ligand/controllers.py
+++ b/flask_ligand/controllers.py
@@ -4,14 +4,15 @@
 # Imports
 # ======================================================================================================================
 from __future__ import annotations
+import flask_ligand
 from json import dumps
 from flask import Flask
 from requests import post
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 from urljoin import url_path_join
-from requests.exceptions import RequestException
 from flask_ligand.extensions.api import abort
+from requests.exceptions import RequestException
 
 
 # ======================================================================================================================
@@ -22,15 +23,16 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 # ======================================================================================================================
-# Functions: Public
+# Functions: Private
 # ======================================================================================================================
-def get_openapi_client_dl_link(  # type: ignore
+def _gen_openapi_client_dl_link(  # type: ignore
     current_app_context: Flask,
     use_private_url: bool,
     gen_lang: str,
     options: dict[str, str],
-) -> dict[Any, Any]:
-    """Get a download link URL from an OpenAPI online generator for a given language.
+) -> dict[str, str]:
+    """
+    Generate a download link URL from an OpenAPI online generator for a given language.
 
     See for more details: https://openapi-generator.tech/docs/generators
 
@@ -44,7 +46,7 @@ def get_openapi_client_dl_link(  # type: ignore
         A dictionary containing the UUID of the client along with download URL for the client.
 
     Raises:
-        werkzeug.exceptions.HTTPException
+        werkzeug.exceptions.HTTPException: An exception containing the HTTP status code and custom message if supplied.
     """
 
     verify_ssl_cert: bool = current_app_context.config["VERIFY_SSL_CERT"]
@@ -55,7 +57,7 @@ def get_openapi_client_dl_link(  # type: ignore
 
     if use_private_url:
         api_spec["servers"][0] = {"url": current_app_context.config["SERVICE_PRIVATE_URL"]}
-    else:
+    else:  # pragma: no cover
         api_spec["servers"][0] = {"url": current_app_context.config["SERVICE_PUBLIC_URL"]}
 
     try:
@@ -71,3 +73,65 @@ def get_openapi_client_dl_link(  # type: ignore
             HTTPStatus(500),
             message=f"The request to the '{open_api_gen_server_url}' server failed!",
         )
+
+
+# ======================================================================================================================
+# Functions: Public
+# ======================================================================================================================
+def gen_typescript_dl_link(current_app_context: Flask, use_private_url: bool) -> dict[str, str]:
+    """
+    Generate a download link URL for a TypeScript client.
+
+    Args:
+        current_app_context: The current Flask app context.
+        use_private_url: Specify whether to use a public or private URL for the generated OpenAPI client.
+
+    Returns:
+        A dictionary containing the UUID of the client along with download URL for the client.
+
+    Raises:
+        werkzeug.exceptions.HTTPException: An exception containing the HTTP status code and custom message if supplied.
+    """
+
+    options = {
+        "npmName": current_app_context.config["OPENAPI_CLIENT_NAME"],
+        "npmVersion": flask_ligand.__version__,
+        "supportsES6": True,
+        "useSingleRequestParameter": True,
+    }
+
+    return _gen_openapi_client_dl_link(
+        current_app_context,
+        use_private_url,
+        "typescript-axios",
+        options,
+    )
+
+
+def gen_python_dl_link(current_app_context: Flask, use_private_url: bool) -> dict[str, str]:
+    """
+    Generate a download link URL for a Python client.
+
+    Args:
+        current_app_context: The current Flask app context.
+        use_private_url: Specify whether to use a public or private URL for the generated OpenAPI client.
+
+    Returns:
+        A dictionary containing the UUID of the client along with download URL for the client.
+
+    Raises:
+        werkzeug.exceptions.HTTPException: An exception containing the HTTP status code and custom message if supplied.
+    """
+
+    options = {
+        "packageName": current_app_context.config["OPENAPI_CLIENT_NAME"].replace("-", "_"),
+        "projectName": current_app_context.config["OPENAPI_CLIENT_NAME"],
+        "packageVersion": flask_ligand.__version__,
+    }
+
+    return _gen_openapi_client_dl_link(
+        current_app_context,
+        use_private_url,
+        "python-prior",
+        options,
+    )

--- a/flask_ligand/default_settings.py
+++ b/flask_ligand/default_settings.py
@@ -245,6 +245,7 @@ ENVIRONMENTS = {
     "stage": StagingConfig,
     "local": FlaskLocalConfig,
     "testing": TestingConfig,
+    "cli": ProdConfig,
 }
 
 
@@ -272,6 +273,8 @@ def flask_environment_configurator(
             ``local``: Configured for use with a local Flask server.
 
             ``testing``: Configured for use in unit testing.
+
+            ``cli``: Configured for use in a production environment without initializing extensions. (Use for CI/CD)
         api_title: The title (name) of the API to display in the OpenAPI documentation.
         api_version: The semantic version for the OpenAPI client.
         openapi_client_name: The package name to use for generated OpenAPI clients.

--- a/flask_ligand/extensions/__init__.py
+++ b/flask_ligand/extensions/__init__.py
@@ -19,16 +19,18 @@ if TYPE_CHECKING:  # pragma: no cover
 # ======================================================================================================================
 # Functions: Public
 # ======================================================================================================================
-def create_api(app: Flask) -> Api:
+def create_api(app: Flask, offline: bool = False) -> Api:
     """Initialize the underlying API, extensions and databases.
 
     Args:
         app: The root Flask app to configure with the given extensions.
+        offline: Initialize the app in 'offline' mode for running Flask sub-commands.
     """
 
     flask_ligand_api = Api(app)
 
-    for extension in (database, jwt):
-        extension.init_app(app)  # type: ignore
+    if not offline:
+        for extension in (database, jwt):
+            extension.init_app(app)  # type: ignore
 
     return flask_ligand_api

--- a/flask_ligand/extensions/api.py
+++ b/flask_ligand/extensions/api.py
@@ -43,6 +43,9 @@ def abort(http_status: HTTPStatus, message: Optional[str] = None) -> None:
     Args:
         http_status: A valid HTTPStatus enum which will be used for reporting the HTTP response status and code.
         message: Custom message to return within the body or a default HTTP status message will be returned instead.
+
+    Raises:
+        werkzeug.exceptions.HTTPException: An exception containing the HTTP status code and custom message if supplied.
     """
 
     message = message if message else http_status.phrase

--- a/flask_ligand/views/openapi.py
+++ b/flask_ligand/views/openapi.py
@@ -4,12 +4,11 @@
 # Imports
 # ======================================================================================================================
 from __future__ import annotations
-import flask_ligand
 from flask import current_app
 from typing import TYPE_CHECKING
 from flask.views import MethodView
 from flask_ligand.extensions.api import Blueprint
-from flask_ligand.controllers import get_openapi_client_dl_link
+from flask_ligand.controllers import gen_python_dl_link, gen_typescript_dl_link
 from flask_ligand.schemas import OpenApiClientDownloadRespSchema, OpenApiClientDownloadQueryArgsSchema
 
 
@@ -18,6 +17,7 @@ from flask_ligand.schemas import OpenApiClientDownloadRespSchema, OpenApiClientD
 # ======================================================================================================================
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Mapping, Any
+
 
 # ======================================================================================================================
 # Globals
@@ -46,23 +46,9 @@ class OpenApiTypescriptAxios(MethodView):
         See for more details: https://openapi-generator.tech/docs/generators
         """
 
-        options = {
-            "npmName": current_app.config["OPENAPI_CLIENT_NAME"],
-            "npmVersion": flask_ligand.__version__,
-            "supportsES6": True,
-            "useSingleRequestParameter": True,
-        }
-
         use_private_url = args.get("use_private_url", True)
 
-        return OpenApiClientDownloadRespSchema().dump(
-            get_openapi_client_dl_link(
-                current_app,
-                use_private_url,
-                "typescript-axios",
-                options,
-            )
-        )
+        return OpenApiClientDownloadRespSchema().dump(gen_typescript_dl_link(current_app, use_private_url))
 
 
 @BLP.route("/python/")
@@ -78,19 +64,6 @@ class OpenApiPython(MethodView):
         See for more details: https://openapi-generator.tech/docs/generators
         """
 
-        options = {
-            "packageName": current_app.config["OPENAPI_CLIENT_NAME"].replace("-", "_"),
-            "projectName": current_app.config["OPENAPI_CLIENT_NAME"],
-            "packageVersion": flask_ligand.__version__,
-        }
-
         use_private_url = args.get("use_private_url", True)
 
-        return OpenApiClientDownloadRespSchema().dump(
-            get_openapi_client_dl_link(
-                current_app,
-                use_private_url,
-                "python",
-                options,
-            )
-        )
+        return OpenApiClientDownloadRespSchema().dump(gen_python_dl_link(current_app, use_private_url))

--- a/tests/unit/test_openapi_api.py
+++ b/tests/unit/test_openapi_api.py
@@ -3,11 +3,25 @@
 # ======================================================================================================================
 # Imports
 # ======================================================================================================================
+from __future__ import annotations
 import pytest
 import flask_ligand
+from typing import TYPE_CHECKING
+from click.testing import CliRunner
 from unittest.mock import MagicMock
+from flask_ligand import create_app
 from pytest_mock import MockerFixture
-from flask_ligand.controllers import get_openapi_client_dl_link
+
+# noinspection PyProtectedMember
+from flask_ligand.controllers import _gen_openapi_client_dl_link, gen_python_dl_link, gen_typescript_dl_link
+
+
+# ======================================================================================================================
+# Type Checking
+# ======================================================================================================================
+if TYPE_CHECKING:
+    from flask import Flask
+
 
 # ======================================================================================================================
 # Globals
@@ -33,11 +47,60 @@ def python_url() -> str:
 
 
 @pytest.fixture(scope="function")
-def mock_get_openapi_client_dl_link(mocker: MockerFixture) -> MagicMock:
-    """Magic Mock of 'flask_ligand.controllers.get_openapi_client_dl_link'."""
+def offline_flask_app(
+    open_api_client_name: str,
+    mocker: MockerFixture,
+) -> Flask:
+    """A basic Flask app ready to be used for offline testing."""
 
-    magic_mock = mocker.create_autospec(spec=get_openapi_client_dl_link)
-    mocker.patch("flask_ligand.views.openapi.get_openapi_client_dl_link", side_effect=magic_mock)
+    mocked_env = {
+        "SERVICE_PUBLIC_URL": "http://public.url",
+        "SERVICE_PRIVATE_URL": "http://private.url",
+        "ALLOWED_ROLES": "user,admin",
+        "OIDC_DISCOVERY_URL": "TESTING",
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "OPENAPI_GEN_SERVER_URL": "http://api.openapi-generator.tech",
+    }
+
+    mocker.patch.dict("os.environ", mocked_env)
+
+    app, _ = create_app(
+        flask_app_name="flask_ligand_offline_unit_testing",
+        flask_env="cli",
+        api_title="Flask Ligand Offline Unit Testing Service",
+        api_version="1.0.1",
+        openapi_client_name=open_api_client_name,
+    )
+
+    return app
+
+
+@pytest.fixture(scope="function")
+def mock_gen_openapi_client_dl_link(mocker: MockerFixture) -> MagicMock:
+    """Magic Mock of 'flask_ligand.controllers._gen_openapi_client_dl_link'."""
+
+    magic_mock = mocker.create_autospec(spec=_gen_openapi_client_dl_link)
+    mocker.patch("flask_ligand.controllers._gen_openapi_client_dl_link", side_effect=magic_mock)
+
+    return magic_mock
+
+
+@pytest.fixture(scope="function")
+def mock_gen_python_dl_link(mocker: MockerFixture) -> MagicMock:
+    """Magic Mock of 'flask_ligand.controllers.gen_python_dl_link'."""
+
+    magic_mock = mocker.create_autospec(spec=gen_python_dl_link)
+    mocker.patch("flask_ligand.cli.gen_python_dl_link", side_effect=magic_mock)
+
+    return magic_mock
+
+
+@pytest.fixture(scope="function")
+def mock_gen_typescript_dl_link(mocker: MockerFixture) -> MagicMock:
+    """Magic Mock of 'flask_ligand.controllers.gen_typescript_dl_link'."""
+
+    magic_mock = mocker.create_autospec(spec=gen_typescript_dl_link)
+    mocker.patch("flask_ligand.cli.gen_typescript_dl_link", side_effect=magic_mock)
 
     return magic_mock
 
@@ -46,42 +109,42 @@ def mock_get_openapi_client_dl_link(mocker: MockerFixture) -> MagicMock:
 # Test Suites
 # ======================================================================================================================
 class TestOpenApiTypescriptAxios(object):
-    """Test cases for getting clients from the 'openapi/typescript-axios/' endpoint."""
+    """Test cases for generating clients from the 'openapi/typescript-axios/' endpoint."""
 
-    def test_get_client_no_params(
-        self, app_test_client, typescript_axios_url, open_api_client_name, mock_get_openapi_client_dl_link
+    def test_gen_client_no_params(
+        self, app_test_client, typescript_axios_url, open_api_client_name, mock_gen_openapi_client_dl_link
     ):
         """Verify that the 'SERVICE_PRIVATE_URL' is used by default when no URL parameters are provided."""
 
         with app_test_client.get(typescript_axios_url):
-            assert mock_get_openapi_client_dl_link.call_args.args[1] is True
+            assert mock_gen_openapi_client_dl_link.call_args.args[1] is True
 
-            assert mock_get_openapi_client_dl_link.call_args.args[2] == "typescript-axios"
+            assert mock_gen_openapi_client_dl_link.call_args.args[2] == "typescript-axios"
 
-            assert mock_get_openapi_client_dl_link.call_args.args[3] == {
+            assert mock_gen_openapi_client_dl_link.call_args.args[3] == {
                 "npmName": open_api_client_name,
                 "npmVersion": flask_ligand.__version__,
                 "supportsES6": True,
                 "useSingleRequestParameter": True,
             }
 
-    def test_get_client_private(self, app_test_client, typescript_axios_url, mock_get_openapi_client_dl_link):
+    def test_gen_client_private(self, app_test_client, typescript_axios_url, mock_gen_openapi_client_dl_link):
         """Verify that the 'SERVICE_PRIVATE_URL' is used by default when explicitly declared in the URL parameters."""
 
         with app_test_client.get(f"{typescript_axios_url}?use_private_url=true"):
-            assert mock_get_openapi_client_dl_link.call_args.args[1] is True
+            assert mock_gen_openapi_client_dl_link.call_args.args[1] is True
 
-    def test_get_client_public(self, app_test_client, typescript_axios_url, mock_get_openapi_client_dl_link):
+    def test_gen_client_public(self, app_test_client, typescript_axios_url, mock_gen_openapi_client_dl_link):
         """Verify that the 'SERVICE_PUBLIC_URL' is used by default when explicitly declared in the URL parameters."""
 
         with app_test_client.get(f"{typescript_axios_url}?use_private_url=false"):
-            assert mock_get_openapi_client_dl_link.call_args.args[1] is False
+            assert mock_gen_openapi_client_dl_link.call_args.args[1] is False
 
 
 class TestNegativeOpenApiTypescriptAxios(object):
     """Negative test cases for getting clients from the 'openapi/typescript-axios/' endpoint."""
 
-    def test_get_client_when_open_svc_unavailable(self, app_test_client, typescript_axios_url):
+    def test_gen_client_when_open_svc_unavailable(self, app_test_client, typescript_axios_url):
         """
         Verify that the correct HTTP code is returned when attempting to get a client when the 'openapi' service is
         unavailable.
@@ -92,41 +155,41 @@ class TestNegativeOpenApiTypescriptAxios(object):
 
 
 class TestOpenApiPython(object):
-    """Test cases for getting clients from the 'openapi/python/' endpoint."""
+    """Test cases for generating clients from the 'openapi/python/' endpoint."""
 
-    def test_get_client_no_params(
-        self, app_test_client, python_url, open_api_client_name, mock_get_openapi_client_dl_link
+    def test_gen_client_no_params(
+        self, app_test_client, python_url, open_api_client_name, mock_gen_openapi_client_dl_link
     ):
         """Verify that the 'SERVICE_PRIVATE_URL' is used by default when no URL parameters are provided."""
 
         with app_test_client.get(python_url):
-            assert mock_get_openapi_client_dl_link.call_args.args[1] is True
+            assert mock_gen_openapi_client_dl_link.call_args.args[1] is True
 
-            assert mock_get_openapi_client_dl_link.call_args.args[2] == "python"
+            assert mock_gen_openapi_client_dl_link.call_args.args[2] == "python-prior"
 
-            assert mock_get_openapi_client_dl_link.call_args.args[3] == {
+            assert mock_gen_openapi_client_dl_link.call_args.args[3] == {
                 "packageName": open_api_client_name.replace("-", "_"),
                 "projectName": open_api_client_name,
                 "packageVersion": flask_ligand.__version__,
             }
 
-    def test_get_client_private(self, app_test_client, python_url, mock_get_openapi_client_dl_link):
+    def test_gen_client_private(self, app_test_client, python_url, mock_gen_openapi_client_dl_link):
         """Verify that the 'SERVICE_PRIVATE_URL' is used by default when explicitly declared in the URL parameters."""
 
         with app_test_client.get(f"{python_url}?use_private_url=true"):
-            assert mock_get_openapi_client_dl_link.call_args.args[1] is True
+            assert mock_gen_openapi_client_dl_link.call_args.args[1] is True
 
-    def test_get_client_public(self, app_test_client, python_url, mock_get_openapi_client_dl_link):
+    def test_gen_client_public(self, app_test_client, python_url, mock_gen_openapi_client_dl_link):
         """Verify that the 'SERVICE_PUBLIC_URL' is used by default when explicitly declared in the URL parameters."""
 
         with app_test_client.get(f"{python_url}?use_private_url=false"):
-            assert mock_get_openapi_client_dl_link.call_args.args[1] is False
+            assert mock_gen_openapi_client_dl_link.call_args.args[1] is False
 
 
 class TestNegativeOpenApiPython(object):
-    """Negative test cases for for getting clients from the 'openapi/python/' endpoint."""
+    """Negative test cases for getting clients from the 'openapi/python/' endpoint."""
 
-    def test_get_client_when_open_svc_unavailable(self, app_test_client, python_url):
+    def test_gen_client_when_open_svc_unavailable(self, app_test_client, python_url):
         """
         Verify that the correct HTTP code is returned when attempting to get a client when the 'openapi' service is
         unavailable.
@@ -134,3 +197,55 @@ class TestNegativeOpenApiPython(object):
 
         with app_test_client.get(python_url) as ret:
             assert ret.status_code == 500
+
+
+class TestOpenApiGenClientCli(object):
+    """Test cases for generating clients from the Flask command-line interface."""
+
+    def test_gen_python_client(self, offline_flask_app, mock_gen_python_dl_link):
+        """Verify that a user can generate a Python client."""
+
+        with offline_flask_app.app_context():
+            runner = CliRunner()
+            result = runner.invoke(offline_flask_app.cli, ["genclient", "python"])
+
+            assert result.exit_code == 0
+
+            assert mock_gen_python_dl_link.call_count == 1
+            assert mock_gen_python_dl_link.call_args.args[1] is False
+
+    def test_gen_python_client_private(self, offline_flask_app, mock_gen_python_dl_link):
+        """Verify that a user can generate a Python client using the SERVICE_PRIVATE_URL."""
+
+        with offline_flask_app.app_context():
+            runner = CliRunner()
+            result = runner.invoke(offline_flask_app.cli, ["genclient", "--private", "python"])
+
+            assert result.exit_code == 0
+
+            assert mock_gen_python_dl_link.call_count == 1
+            assert mock_gen_python_dl_link.call_args.args[1] is True
+
+    def test_gen_typescript_client(self, offline_flask_app, mock_gen_typescript_dl_link):
+        """Verify that a user can generate a TypeScript client."""
+
+        with offline_flask_app.app_context():
+            runner = CliRunner()
+            result = runner.invoke(offline_flask_app.cli, ["genclient", "typescript"])
+
+            assert result.exit_code == 0
+
+            assert mock_gen_typescript_dl_link.call_count == 1
+            assert mock_gen_typescript_dl_link.call_args.args[1] is False
+
+    def test_gen_typescript_client_private(self, offline_flask_app, mock_gen_typescript_dl_link):
+        """Verify that a user can generate a TypeScript client using the SERVICE_PRIVATE_URL."""
+
+        with offline_flask_app.app_context():
+            runner = CliRunner()
+            result = runner.invoke(offline_flask_app.cli, ["genclient", "--private", "typescript"])
+
+            assert result.exit_code == 0
+
+            assert mock_gen_typescript_dl_link.call_count == 1
+            assert mock_gen_typescript_dl_link.call_args.args[1] is True

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -519,7 +519,7 @@ class TestFlaskEnvironmentConfigurator(object):
     def test_environment_count(self):
         """Verify that the expected number of environments exist. (No more, no less)"""
 
-        assert len(ENVIRONMENTS) == 4
+        assert len(ENVIRONMENTS) == 5
 
     @pytest.mark.parametrize(
         "env_name,env_config_class",


### PR DESCRIPTION
In order to support this feature well I created a new environment "cli" which will allow the service to run without initializing Flask extensions.

I found a bunch of minor typos again that I fixed as part of this feature because I'm lazy and don't want to create another commit.