### PR TITLE
[FIX:robot:] Revert Back to SQLAlchemy 1.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
         -   "types-requests~=2.28"
         -   "types-setuptools~=63.4"
         -   "types-smorest~=1.1"
+        -   "types-SQLAlchemy~=1.4"
         -   "types-sqlalchemy-utils~=1.0"
         -   "types-urllib3<1.27"
 -   repo: https://github.com/rstcheck/rstcheck

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,5 +23,6 @@ types-PyYAML~=6.0
 types-requests~=2.28
 types-setuptools~=67.7
 types-smorest~=1.1
+types-SQLAlchemy~=1.4
 types-sqlalchemy-utils~=1.0
 types-urllib3<1.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Dependency constraints
 flask~=2.2
 PyJWT~=2.6
-sqlalchemy~=2.0
+sqlalchemy~=1.4
 cryptography>=36.0.2
 # Installation requirements
 flask-cors~=3.0


### PR DESCRIPTION
Everything looked fine with SQLAlchemy 2.0 with the full test suite, but building the documentation uncovered an incompatibility not discovered by the test suite. Reverting back to the previous version and I will investigate the issue at a later time.