### PR TITLE
Fix Read the Docs AGAIN!

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.12"
 
 sphinx:
   builder: html
@@ -16,6 +16,7 @@ sphinx:
 
 python:
   install:
-    - requirements: docs/requirements.txt
-    - method: pip
+    - method: uv
+      command: pip
       path: .
+      requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,12 +183,18 @@ hoverxref_intersphinx = [
 
 # -- Configuration for 'autodoc' extension -------------------------------------------------
 
-autodoc_typehints = "signature"
+
+autodoc_typehints = "none"
 napoleon_use_rtype = False  # sphinx.ext.napoleon setting
+
+# An upstream Meta class is confusing typehints
+suppress_warnings = ["sphinx_autodoc_typehints.forward_reference"]
+
 # Don't show "None" return types, but show all others
 typehints_document_rtype_none = False
-# Show the return type inline with the return description
-# instead of as a separate block
+
+# Show the return type inline with the return description instead of as a separate block
 typehints_use_rtype = False
+
 always_use_bars_union = True
 typehints_defaults = "comma"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
-sphinx==8.1.3
+sphinx==8.2.3
 myst-parser==4.0.1
-linkify-it-py~=2.1.0
-sphinx-hoverxref~=1.4.2
-sphinx-issues~=5.0.1
-sphinx-toolbox~=4.1.2
+linkify-it-py==2.1.0
+sphinx-hoverxref==1.4.2
+sphinx-issues==5.0.1
+sphinx-toolbox==4.1.2
+sphinx-autodoc-typehints==3.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ clean-all = [
 	"rm -fr .pytest_cache/",
     "rm -fr .ruff_cache/",
     "rm -fr .mypy_cache/",
+    "rm -fr docs/_build/",
     "find . -name '*.pyc' -exec rm -f {{}} +",
     "find . -name '*.pyo' -exec rm -f {{}} +",
 	"find . -name '*~' -exec rm -f {{}} +",
@@ -293,16 +294,21 @@ post-install-commands = [
 # This is an intentional duplicate of 'docs/requirements' dependencies in order to allow for easy local doc generation.
 # KEEP THIS IN SYNC WITH DOCS DEPENDENCIES!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 dependencies = [
-    "sphinx==8.1.3",
-    "myst-parser~=4.0.1",
-    "linkify-it-py~=2.1.0",
-    "sphinx-hoverxref~=1.4.2",
-    "sphinx-issues~=5.0.1",
-    "sphinx-toolbox~=4.1.2"
+    "sphinx==8.2.3",
+    "myst-parser==4.0.1",
+    "linkify-it-py==2.1.0",
+    "sphinx-hoverxref==1.4.2",
+    "sphinx-issues==5.0.1",
+    "sphinx-toolbox==4.1.2",
+    "sphinx-autodoc-typehints==3.3.0"
 ]
+post-install-commands = []
 
 [tool.hatch.envs.docs.scripts]
-gen-docs = "cd docs && make html"
+gen-docs = [
+    "clean-all",
+    "cd docs && make html"
+]
 
 [tool.hatch.envs.hatch-test]
 # This is an intentional duplicate of 'test' dependencies in order to fix a bug in hatch


### PR DESCRIPTION
This is getting tiring. I hate CI. I hate documentation. I hate Python.

Okay, I moved the pins on doc related dependencies slightly to allow the use of warning suppression when generating type hints in the documentation. This also required chaninging the target 'rtd' Python to 3.12 because 'sphinx' 8.2.3 only supports 3.11 and above. I changed the Python package installer to UV just in case there was an installation mismatch when using 'pip'.

Changed the 'docs' Hatch environment to only load dependencies for 'docs' and avoid loading the full 'dev' environment. Updated 'clean-all' to actually clean out the 'docs' build directory. Forced 'gen-docs' to clean the whole repo before generating docs. (Should fix most type check problems on type hinting.)