### PR TITLE
:bug: Update OpenAPI Generator

### DIFF
--- a/.run/Flask - Debug.run.xml
+++ b/.run/Flask - Debug.run.xml
@@ -3,13 +3,15 @@
     <option name="flaskDebug" value="true" />
     <option name="flaskEnv" value="local" />
     <module name="flask-ligand" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <option name="SDK_HOME" value="$USER_HOME$/.virtualenvs/flask-ligand/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="DEBUG_JUST_MY_CODE" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <EXTENSION ID="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />
@@ -18,9 +20,10 @@
       <option name="IS_IGNORE_MISSING_FILES" value="false" />
       <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
       <ENTRIES>
-        <ENTRY IS_ENABLED="true" PARSER="runconfig" />
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </EXTENSION>
+    <option name="RUN_TOOL" value="" />
     <option name="launchJavascriptDebuger" value="false" />
     <method v="2" />
   </configuration>

--- a/.run/Flask.run.xml
+++ b/.run/Flask.run.xml
@@ -2,13 +2,15 @@
   <configuration default="false" name="Flask" type="Python.FlaskServer" nameIsGenerated="true">
     <option name="flaskEnv" value="local" />
     <module name="flask-ligand" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <option name="SDK_HOME" value="$USER_HOME$/.virtualenvs/flask-ligand/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="DEBUG_JUST_MY_CODE" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <EXTENSION ID="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />
@@ -17,9 +19,10 @@
       <option name="IS_IGNORE_MISSING_FILES" value="false" />
       <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
       <ENTRIES>
-        <ENTRY IS_ENABLED="true" PARSER="runconfig" />
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </EXTENSION>
+    <option name="RUN_TOOL" value="" />
     <option name="launchJavascriptDebuger" value="false" />
     <method v="2" />
   </configuration>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,13 @@ services:
       - backend
     command: start-dev --import-realm
 
+  openapi:
+    container_name: openapi_flask_ligand_example
+    image: openapitools/openapi-generator-online:v7.16.0
+    ports:
+      - '8888:8080'
+    command: java -Dio.swagger.v3.parser.util.RemoteUrl.trustAll=true -jar /generator/openapi-generator-online.jar
+
 networks:
   backend:
     name: backend

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,23 +10,6 @@ Release v\ |version| (:ref:`Changelog <changelog>`)
    :start-after: excerpt-start
    :end-before: excerpt-end
 
-Why not Use FastAPI Instead?
-----------------------------
-
-This library mimics many of the features of `FastAPI`_, well, because `FastAPI`_ is really good! However, the
-:doc:`Flask <flask:index>` ecosystem is much larger than `FastAPI`_ giving many more options when it comes to high
-quality extensions. The one large advantage `FastAPI`_ has over :doc:`Flask <flask:index>` currently is support for
-asynchronous I/O via `Starlette`_ which can improve performance dramatically.
-
-:doc:`Flask's asyncio journey <flask:async-await>` has just started and :doc:`Quart <quart:index>` most likely being the
-future for asyncio in the :doc:`Flask <flask:index>` ecosystem. This library was inspired by FastAPI and I think anyone
-considering starting a greenfield microservice should give serious consideration to using `FastAPI`_.
-
-However, if you have an existing :doc:`Flask <flask:index>` microservice needing an upgrade in feature set then this
-library brings together the best extensions that the :doc:`Flask <flask:index>` ecosystem has to offer! If you're
-creating a greenfield microservice then this library lets you tap into a wide range of other
-:doc:`Flask extensions <flask:extensions>` that will help you solve your problem(s) faster.
-
 Guides
 ======
 

--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -13,6 +13,8 @@ For OpenAPI client generation to work properly your ``flask-ligand`` based micro
 public OpenAPI generator server URL located at http://api.openapi-generator.tech is also available, but since it is not
 a secure endpoint, it is recommended for use only in testing.
 
+.. important:: Currently ``flask-ligand`` only supports `openapi_generator v7.16.0`_!
+
 Online Generation
 =================
 
@@ -56,3 +58,4 @@ Generate a Python client download link with your ``flask-ligand`` based microser
 
 .. _`setting configured`: configuration.html#prod
 .. _`production environment`: configuration.html#prod
+.. _`openapi_generator v7.16.0`: https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.16.0

--- a/flask_ligand/controllers.py
+++ b/flask_ligand/controllers.py
@@ -134,6 +134,6 @@ def gen_python_dl_link(current_app_context: Flask, use_private_url: bool) -> dic
     return _gen_openapi_client_dl_link(
         current_app_context,
         use_private_url,
-        "python-prior",
+        "python-pydantic-v1",
         options,
     )

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,0 +1,37 @@
+"""Tests for the built-in Flask sub-commands for OpenAPI related functionality."""
+
+# ======================================================================================================================
+# Imports
+# ======================================================================================================================
+from click.testing import CliRunner
+
+
+# ======================================================================================================================
+# Test Suites
+# ======================================================================================================================
+class TestOpenApiGenClientCli(object):
+    """Test cases for generating clients from the Flask command-line interface."""
+
+    def test_gen_python_client(self, app_test_client):
+        """Verify that a user can generate a Python client."""
+
+        with app_test_client.application.app_context():
+            runner = CliRunner()
+            result = runner.invoke(app_test_client.application.cli, ["genclient", "python"])
+
+            assert result.exit_code == 0
+            assert result.output.startswith(
+                f"{app_test_client.application.config['OPENAPI_GEN_SERVER_URL']}/api/gen/download"
+            )
+
+    def test_gen_typescript_client(self, app_test_client):
+        """Verify that a user can generate a TypeScript client."""
+
+        with app_test_client.application.app_context():
+            runner = CliRunner()
+            result = runner.invoke(app_test_client.application.cli, ["genclient", "typescript"])
+
+            assert result.exit_code == 0
+            assert result.output.startswith(
+                f"{app_test_client.application.config['OPENAPI_GEN_SERVER_URL']}/api/gen/download"
+            )

--- a/tests/unit/test_openapi_api.py
+++ b/tests/unit/test_openapi_api.py
@@ -171,7 +171,7 @@ class TestOpenApiPython(object):
         with app_test_client.get(python_url):
             assert mock_gen_openapi_client_dl_link.call_args.args[1] is True
 
-            assert mock_gen_openapi_client_dl_link.call_args.args[2] == "python-prior"
+            assert mock_gen_openapi_client_dl_link.call_args.args[2] == "python-pydantic-v1"
 
             assert mock_gen_openapi_client_dl_link.call_args.args[3] == {
                 "packageName": open_api_client_name.replace("-", "_"),


### PR DESCRIPTION
Update the 'openapi-generator' to v7.16.0 syntax and added integration tests because I discovered it is a real pain to test this without a live integration environment.

I updated the documentation to mention the limitation given a bug in versions after v7.16.0 that cause a crash. :shrug:

Removed some other docs that were no longer relevant.